### PR TITLE
Add onBoot Command to .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,3 @@
 language = "python3"
 run = "python main.py" 
+onBoot = "poetry install"


### PR DESCRIPTION
Of the Python challenges, this Repl was created with Bash set as the language instead of Python.

I think for all Python Repls, there should be an `onBoot` configured so when a user does actually want to run their code, they don't have to wait for the dependencies.

At the very least I wanted to suggest it for this one already though, as users currently have to manually perform `poetry install` in the terminal before they can run the project.

I still think this change is worth having even in the scenario you can make it a Python Repl instead of a Bash Repl as that will allow the command to execute automatically, rather than make a user wait 20-30 seconds after the first run.

Docs:
https://docs.repl.it/repls/dot-replit#other-configuration

The command will execute immediately after the project is opened and the shell boots, but can take up to 20-30 seconds before dependencies are actually installed. As far as I know, there's no harm if the Python Repl, or user perform `poetry install` before the `onBoot` is finished.

---

I would like to PR this to the other Python boilerplate projects, but first I'll wait for feedback on this one.