### PR TITLE
fix: use correct method for list comparing

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -8,8 +8,8 @@ class DemographicAnalyzerTestCase(unittest.TestCase):
     def test_race_count(self):
         actual = self.data['race_count'].tolist()
         expected = [27816, 3124, 1039, 311, 271]
-        self.assertAlmostEqual(actual, expected, msg="Expected race count values to be [27816, 3124, 1039, 311, 271]")
-    
+        self.assertCountEqual(actual, expected, msg="Expected race count values to be [27816, 3124, 1039, 311, 271]")
+
     def test_average_age_men(self):
         actual = self.data['average_age_men']
         expected = 39.4


### PR DESCRIPTION
`assertAlmostEqual` is able to determine if lists are equal, but it cannot determine if corresponding elements are almost equal. `assertCountEqual` checks if lists have the same elements, regardless of the order. As `README.md` doesn't mention sorting the values in answer it seems to be reasonable to allow not sorted answer.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/39243#issuecomment-789049536

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
