### PR TITLE
Delete .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "python3"
-run = "python main.py" 


### PR DESCRIPTION
I work at Replit (dave@repl.it) as a Support Engineer.

This .replit is out of date and so breaks repls on import. Remove it (from this repo and all others) and this will import cleanly without errors.

Checklist:

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
